### PR TITLE
fix: restore LSPosed ambient and Dolby chains

### DIFF
--- a/base-fix/hook/resources/AndroidManifest.xml
+++ b/base-fix/hook/resources/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="1100"
-    android:versionName="1.1.0"
+    android:versionCode="1101"
+    android:versionName="1.1.1"
     android:compileSdkVersion="36"
     android:compileSdkVersionCodename="16"
     package="com.aclaniakea.colorosostatsguard"
@@ -10,6 +10,7 @@
     <uses-sdk
         android:minSdkVersion="31"
         android:targetSdkVersion="35"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
     <application
         android:label="@string/app_name"
         android:hasCode="true"
@@ -27,5 +28,14 @@
         <meta-data
             android:name="xposedscope"
             android:resource="@array/xposed_scope"/>
+        <service
+            android:name="com.aclaniakea.dolbybridge.DolbyBridgeService"
+            android:exported="true"
+            android:label="Dolby Bridge Service"
+            android:process=":dolbybridge">
+            <intent-filter>
+                <action android:name="com.oplus.dolbyeffect.controlservice.START"/>
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/base-fix/hook/resources/assets/xposed_init
+++ b/base-fix/hook/resources/assets/xposed_init
@@ -11,3 +11,5 @@ com.aclaniakea.colorosvoicewakeupbridge.ColorOSVoiceWakeupBridge
 com.aclaniakea.soundtriggerguard.SoundTriggerTrackerGuard
 com.aclaniakea.batteryhealthbridge.BatteryHealthBridge
 com.aclaniakea.coloroscryptoengbridge.ColorOsCryptoEngBridge
+com.aclaniakea.orealityguard.OrealityDisableBridge
+com.aclaniakea.dolbybridge.SoundEffectsMenuFix

--- a/base-fix/hook/sources/com/aclaniakea/dolbybridge/DolbyBridgeService.java
+++ b/base-fix/hook/sources/com/aclaniakea/dolbybridge/DolbyBridgeService.java
@@ -1,0 +1,293 @@
+package com.aclaniakea.dolbybridge;
+
+import android.app.Service;
+import android.content.Intent;
+import android.media.audiofx.AudioEffect;
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.Parcel;
+import android.os.RemoteException;
+import android.util.Log;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Dolby control-service bridge for the ColorOS port.
+ *
+ * The port Settings APK binds to {@code com.oplus.dolbyeffect.controlservice.START}
+ * (implementing {@code com.oplus.audio.effectcenter.IOplusEffectService}) to drive the
+ * Dolby Atmos UI. The port ROM ships the vendor DMS/DAX HAL but no control service, so
+ * this service fills that gap: it attaches to the DAX effect
+ * (9d4921da-8225-4f29-aefa-39537a04bcaa) via AudioEffect and maps the OPlus AIDL
+ * surface onto the DAX parameters verified on TB710FU:
+ *   param 5 : Dolby on/off (int)
+ *   param 6 : current profile name (string, e.g. "Dynamic")
+ *   param 4 : active endpoint (string)
+ */
+public class DolbyBridgeService extends Service {
+    static final String TAG = "DolbyBridge";
+    static final String DESCRIPTOR = "com.oplus.audio.effectcenter.IOplusEffectService";
+    static final String CALLBACK_DESCRIPTOR = "com.oplus.audio.effectcenter.IEffectServiceCallback";
+    static final UUID DAX = UUID.fromString("9d4921da-8225-4f29-aefa-39537a04bcaa");
+
+    static final int DOLBY_ONOFF_ID = 5;
+    static final int PROFILE_NAME_ID = 6;
+    static final int ENDPOINT_ID = 4;
+
+    // OPlus scene id -> DAX profile id (dax-default.xml)
+    static final int[] SCENE_TO_PROFILE = {0, 2, 1, 8}; // 智能, 音乐, 影院, 游戏
+    static final String[] PROFILE_TO_SCENE = {"0", "2", "1", "3", "4", "0", "0", "0", "8"}; // by DAX id
+
+    AudioEffect mFx;
+    Method mSetP, mGetP;
+    final List<IBinder> mCallbacks = new ArrayList<>();
+    volatile boolean mEnabled = true;
+    volatile int mScene = 0;
+
+    final Binder mStub = new Binder() {
+        @Override
+        protected boolean onTransact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
+            if (code >= 1 && code <= 16777215) data.enforceInterface(DESCRIPTOR);
+            switch (code) {
+                case 1: // setEnabled(boolean)
+                    setEnabled(data.readInt() != 0);
+                    reply.writeNoException();
+                    return true;
+                case 2: // getEnabled() -> boolean
+                    reply.writeNoException();
+                    reply.writeInt(getEnabled() ? 1 : 0);
+                    return true;
+                case 3: // setMusicIeqPreset(int)
+                    setMusicIeqPreset(data.readInt());
+                    reply.writeNoException();
+                    return true;
+                case 4: // getMusicIeqPreset() -> int
+                    reply.writeNoException();
+                    reply.writeInt(getMusicIeqPreset());
+                    return true;
+                case 5: // setCustomGeqBandGains(int[], boolean, int)
+                    reply.writeNoException();
+                    return true;
+                case 6: // getEffectCategory() -> int
+                    reply.writeNoException();
+                    reply.writeInt(1);
+                    return true;
+                case 7: // setMusicGeqBandGains(int[])
+                    reply.writeNoException();
+                    return true;
+                case 8: // getMusicGeqBandGains() -> int[]
+                    reply.writeNoException();
+                    reply.writeIntArray(new int[10]);
+                    return true;
+                case 9: // isBtDeviceSupported(String) -> boolean
+                    data.readString();
+                    reply.writeNoException();
+                    reply.writeInt(0);
+                    return true;
+                case 10: // setParameter(String, String)
+                    setParameter(data.readString(), data.readString());
+                    reply.writeNoException();
+                    return true;
+                case 11: // getParameters(String) -> String
+                    reply.writeNoException();
+                    reply.writeString(getParameters(data.readString()));
+                    return true;
+                case 12: // registerCallback(IEffectServiceCallback)
+                    registerCb(data.readStrongBinder());
+                    reply.writeNoException();
+                    return true;
+                case 13: // unRegisterCallback(IEffectServiceCallback)
+                    unregisterCb(data.readStrongBinder());
+                    reply.writeNoException();
+                    return true;
+                case 14: // setEffectCategory(int)
+                    setEffectCategory(data.readInt());
+                    reply.writeNoException();
+                    return true;
+                case 15: // getCustomGeqBandGains(boolean) -> int[]
+                    reply.writeNoException();
+                    reply.writeIntArray(new int[10]);
+                    return true;
+                case 16: // getCustomPresetEQType(boolean) -> int
+                    reply.writeNoException();
+                    reply.writeInt(0);
+                    return true;
+                default:
+                    return super.onTransact(code, data, reply, flags);
+            }
+        }
+    };
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        try {
+            Constructor<AudioEffect> ctor = AudioEffect.class.getDeclaredConstructor(UUID.class, UUID.class, int.class, int.class);
+            ctor.setAccessible(true);
+            mFx = ctor.newInstance(DAX, DAX, 100, 0);
+            mSetP = AudioEffect.class.getMethod("setParameter", byte[].class, byte[].class);
+            mGetP = AudioEffect.class.getMethod("getParameter", byte[].class, byte[].class);
+            mEnabled = daxGetInt(DOLBY_ONOFF_ID) != 0;
+            mScene = sceneFromProfile(daxGetStr(PROFILE_NAME_ID));
+            Log.i(TAG, "DAX attached, enabled=" + mEnabled + " scene=" + mScene);
+        } catch (Throwable t) {
+            Log.e(TAG, "DAX attach failed", t);
+            mFx = null;
+        }
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mStub;
+    }
+
+    @Override
+    public void onDestroy() {
+        synchronized (mCallbacks) { mCallbacks.clear(); }
+        if (mFx != null) {
+            try { mFx.release(); } catch (Throwable ignored) {}
+        }
+        super.onDestroy();
+    }
+
+    // ---------- IOplusEffectService surface ----------
+
+    synchronized void setEnabled(boolean on) {
+        mEnabled = on;
+        if (mFx != null) {
+            try {
+                mSetP.invoke(mFx, le(DOLBY_ONOFF_ID), new byte[]{0,0,0,0,(byte)(on?1:0),0,0,0});
+            } catch (Throwable t) { Log.w(TAG, "setEnabled failed", t); }
+        }
+        notifyCallbacks(1); // EffectServiceStatusChangeCallback
+    }
+
+    boolean getEnabled() {
+        return mEnabled;
+    }
+
+    synchronized void setMusicIeqPreset(int scene) {
+        mScene = scene;
+        if (scene >= 0 && scene < SCENE_TO_PROFILE.length && mFx != null) {
+            trySetProfile(SCENE_TO_PROFILE[scene]);
+        }
+        notifyCallbacks(4); // EffectServiceProfileCallback
+    }
+
+    int getMusicIeqPreset() {
+        return mScene;
+    }
+
+    void setEffectCategory(int cat) {
+        // 1 = Dolby. No privileged settings writes from a normal-app service.
+    }
+
+    void setParameter(String key, String value) {
+        // EQ toggle persisted by the Settings side; nothing privileged to write here.
+    }
+
+    String getParameters(String key) {
+        if ("dolby_get_dolby_state".equals(key)) return "state_" + (mEnabled ? 1 : 0);
+        if ("dolby_get_dolby_profile".equals(key)) return "profile_" + mScene;
+        if ("dolby_get_device_status".equals(key)) return "0";
+        if ("dolby_geq_on_off".equals(key)) return "false";
+        return "";
+    }
+
+    // ---------- DAX helpers ----------
+
+    static byte[] le(int v) {
+        return new byte[]{(byte) v, (byte) (v >> 8), (byte) (v >> 16), (byte) (v >> 24)};
+    }
+
+    static int rdle(byte[] a, int off) {
+        return (a[off] & 0xff) | ((a[off+1] & 0xff) << 8) | ((a[off+2] & 0xff) << 16) | ((a[off+3] & 0xff) << 24);
+    }
+
+    int daxGetInt(int id) {
+        if (mGetP == null) return 0;
+        try {
+            byte[] v = new byte[8];
+            mGetP.invoke(mFx, le(id), v);
+            return rdle(v, 0);
+        } catch (Throwable t) { return 0; }
+    }
+
+    String daxGetStr(int id) {
+        if (mGetP == null) return "";
+        try {
+            byte[] v = new byte[64];
+            Object rc = mGetP.invoke(mFx, le(id), v);
+            int n = rc instanceof Integer ? (Integer) rc : 0;
+            if (n > 0 && n <= v.length) return new String(v, 0, n, StandardCharsets.ISO_8859_1).trim();
+        } catch (Throwable ignored) {}
+        return "";
+    }
+
+    /**
+     * Profile switch. The DAX small-id space exposes no validated profile selector on
+     * TB710FU, and blind writes to unknown ids crash the DMS/audio HAL, so we only
+     * persist the selection and let the UI reflect it. (Bottom-level DMS profile
+     * application is a follow-up once a safe param is identified.)
+     */
+    void trySetProfile(int daxProfile) {
+        Log.i(TAG, "scene switch persisted (scene=" + mScene + ", dax=" + daxProfile + ")");
+    }
+
+    static int daxProfileNameToId(String name) {
+        if ("Movie".equals(name)) return 1;
+        if ("Music".equals(name)) return 2;
+        if ("Voice".equals(name)) return 3;
+        if ("SpatialAudio".equals(name)) return 4;
+        if ("Game".equals(name)) return 8;
+        return 0; // Dynamic / unknown
+    }
+
+    static int sceneFromProfile(String name) {
+        int pid = daxProfileNameToId(name);
+        switch (pid) {
+            case 1: return 2; // Movie -> 影院
+            case 2: return 1; // Music -> 音乐
+            case 8: return 3; // Game -> 游戏
+            default: return 0; // Dynamic -> 智能
+        }
+    }
+
+    void registerCb(IBinder b) {
+        if (b == null) return;
+        synchronized (mCallbacks) { if (!mCallbacks.contains(b)) mCallbacks.add(b); }
+    }
+
+    void unregisterCb(IBinder b) {
+        synchronized (mCallbacks) { mCallbacks.remove(b); }
+    }
+
+    void notifyCallbacks(int cbCode) {
+        List<IBinder> snapshot;
+        synchronized (mCallbacks) { snapshot = new ArrayList<>(mCallbacks); }
+        for (IBinder b : snapshot) {
+            if (b == null) continue;
+            try {
+                Parcel data = Parcel.obtain();
+                Parcel reply = Parcel.obtain();
+                data.writeInterfaceToken(CALLBACK_DESCRIPTOR);
+                switch (cbCode) {
+                    case 1: // EffectServiceStatusChangeCallback
+                        b.transact(1, data, reply, 0);
+                        break;
+                    case 4: // EffectServiceProfileCallback(int)
+                        data.writeInt(mScene);
+                        b.transact(4, data, reply, 0);
+                        break;
+                }
+                reply.recycle();
+                data.recycle();
+            } catch (Throwable ignored) {}
+        }
+    }
+}

--- a/base-fix/hook/sources/com/aclaniakea/dolbybridge/SoundEffectsMenuFix.java
+++ b/base-fix/hook/sources/com/aclaniakea/dolbybridge/SoundEffectsMenuFix.java
@@ -1,0 +1,46 @@
+package com.aclaniakea.dolbybridge;
+
+import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
+/**
+ * Keeps the sound-effects mode menu interactive on this port.
+ *
+ * With OReality removed the menu map ends up with a single entry (1=杜比全景声),
+ * so Settings auto-disables the menu (one-choice mode). We re-add the
+ * "原始" (OFF) entry so the user can toggle between OFF and Dolby Atmos, and
+ * reflect the real Dolby state instead of the stale service-less default.
+ */
+public final class SoundEffectsMenuFix implements IXposedHookLoadPackage {
+    private static final String TARGET = "com.android.settings";
+    private static final String FRAGMENT = "com.oplus.settings.feature.soundeffects.view.SoundEffectsFragment";
+
+    public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lp) {
+        if (!TARGET.equals(lp.packageName)) return;
+        try {
+            XposedHelpers.findAndHookMethod(FRAGMENT, lp.classLoader, "updateSoundEffectsMenu",
+                    new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(MethodHookParam p) {
+                            try {
+                                Object map = XposedHelpers.getObjectField(p.thisObject, "mSoundEffectValueToTitleMap");
+                                if (map instanceof java.util.Map) {
+                                    java.util.Map<Object, Object> m = (java.util.Map<Object, Object>) map;
+                                    if (!m.containsKey("0")) {
+                                        m.put("0", "原始");
+                                        XposedBridge.log("SoundEffectsMenuFix: added 原始 OFF entry, size=" + m.size());
+                                    }
+                                }
+                            } catch (Throwable t) {
+                                XposedBridge.log("SoundEffectsMenuFix: map patch failed " + t);
+                            }
+                        }
+                    });
+        } catch (Throwable t) {
+            XposedBridge.log("SoundEffectsMenuFix: hook failed " + t);
+        }
+    }
+}

--- a/base-fix/hook/sources/com/aclaniakea/oplusambientcolorsensorbridge/AmbientColorSensorBridge.java
+++ b/base-fix/hook/sources/com/aclaniakea/oplusambientcolorsensorbridge/AmbientColorSensorBridge.java
@@ -303,25 +303,35 @@ public final class AmbientColorSensorBridge implements IXposedHookLoadPackage {
 
     private static int hookMethod(ClassLoader classLoader, String str) {
         try {
-            XposedHelpers.findAndHookMethod(TARGET_CLASS, classLoader, str, new Object[]{SensorEvent.class, new XC_MethodHook() { // from class: com.aclaniakea.oplusambientcolorsensorbridge.AmbientColorSensorBridge.6
-                protected void beforeHookedMethod(XC_MethodHook.MethodHookParam methodHookParam) {
-                    float[] fArr;
-                    if (methodHookParam.args == null || methodHookParam.args.length == 0 || !(methodHookParam.args[AmbientColorSensorBridge.CCT_INDEX] instanceof SensorEvent) || (fArr = ((SensorEvent) methodHookParam.args[AmbientColorSensorBridge.CCT_INDEX]).values) == null || fArr.length <= AmbientColorSensorBridge.FRAMEWORK_LUX_INDEX) {
-                        return;
+            Class<?> target = XposedHelpers.findClass(TARGET_CLASS, classLoader);
+            XposedBridge.hookAllMethods(target, str, new XC_MethodHook() {
+                protected void beforeHookedMethod(XC_MethodHook.MethodHookParam p) {
+                    // ColorOS revisions changed this method's extra arguments. Find the
+                    // SensorEvent instead of requiring the old one-argument signature.
+                    SensorEvent event = null;
+                    if (p.args != null) {
+                        for (Object arg : p.args) {
+                            if (arg instanceof SensorEvent) {
+                                event = (SensorEvent) arg;
+                                break;
+                            }
+                        }
                     }
-                    float f = fArr[AmbientColorSensorBridge.CCT_INDEX];
-                    float f2 = fArr[AmbientColorSensorBridge.REAL_LUX_INDEX];
-                    if (!AmbientColorSensorBridge.isFinite(f) || !AmbientColorSensorBridge.isFinite(f2) || f < 1000.0f || f > 20000.0f || f2 < 0.0f || f2 > 200000.0f) {
-                        return;
-                    }
-                    float f3 = fArr[AmbientColorSensorBridge.FRAMEWORK_LUX_INDEX];
-                    fArr[AmbientColorSensorBridge.FRAMEWORK_LUX_INDEX] = f2;
-                    int iIncrementAndGet = AmbientColorSensorBridge.REMAP_COUNT.incrementAndGet();
-                    if (iIncrementAndGet <= 5) {
-                        XposedBridge.log("AmbientColorSensorBridge: remapped sample #" + iIncrementAndGet + " cct=" + f + " lux=" + f2 + " oldIndex9=" + f3);
+                    if (event == null || event.values == null || event.values.length <= FRAMEWORK_LUX_INDEX) return;
+                    float cct = event.values[CCT_INDEX];
+                    float lux = event.values[REAL_LUX_INDEX];
+                    if (!isFinite(cct) || !isFinite(lux) || cct < 1000.0f || cct > 20000.0f
+                            || lux < 0.0f || lux > 200000.0f) return;
+                    float old = event.values[FRAMEWORK_LUX_INDEX];
+                    event.values[FRAMEWORK_LUX_INDEX] = lux;
+                    int count = REMAP_COUNT.incrementAndGet();
+                    if (count <= 5) {
+                        XposedBridge.log(TAG + ": remapped sample #" + count + " cct=" + cct
+                                + " lux=" + lux + " oldIndex9=" + old);
                     }
                 }
-            }});
+            });
+            XposedBridge.log(TAG + ": hookAllMethods installed for " + str);
             return REAL_LUX_INDEX;
         } catch (Throwable th) {
             XposedBridge.log("AmbientColorSensorBridge: failed to hook " + str);

--- a/base-fix/hook/sources/com/aclaniakea/orealityguard/OrealityDisableBridge.java
+++ b/base-fix/hook/sources/com/aclaniakea/orealityguard/OrealityDisableBridge.java
@@ -1,0 +1,46 @@
+package com.aclaniakea.orealityguard;
+
+import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
+/**
+ * Disables the broken AudioX/OReality effect path on this ColorOS port.
+ *
+ * The source ROM gates the "OReality 音效" menu on the
+ * {@code oplus.software.audio.audiox_support} feature, which is baked into
+ * the compiled feature table on this port. Its effect engine descriptor
+ * (41f6c0f4-...) is missing on the Lenovo TB710FU vendor, so selecting it
+ * fails with AudioEffect init error -3. This bridge forces both feature
+ * probes to false inside Settings so the sound-effects page shows only the
+ * working Dolby menu.
+ */
+public final class OrealityDisableBridge implements IXposedHookLoadPackage {
+    private static final String TARGET = "com.android.settings";
+
+    public void handleLoadPackage(XC_LoadPackage.LoadPackageParam loadPackageParam) {
+        if (!TARGET.equals(loadPackageParam.packageName)) {
+            return;
+        }
+        for (String cls : new String[]{
+                "com.oplus.settings.utils.SysFeatureUtils",
+                "com.oplus.settings.utils.FeatureUtils"}) {
+            try {
+                XposedHelpers.findAndHookMethod(cls, loadPackageParam.classLoader,
+                        "isOrealitySupported",
+                        new XC_MethodHook() {
+                            @Override
+                            protected void beforeHookedMethod(MethodHookParam methodHookParam) {
+                                methodHookParam.setResult(Boolean.FALSE);
+                            }
+                        });
+                XposedBridge.log("OrealityDisableBridge: disabled " + cls);
+            } catch (Throwable th) {
+                XposedBridge.log("OrealityDisableBridge: failed " + cls);
+                XposedBridge.log(th);
+            }
+        }
+    }
+}

--- a/base-fix/hook/tools/build_integrated_hook.py
+++ b/base-fix/hook/tools/build_integrated_hook.py
@@ -81,7 +81,7 @@ def main() -> None:
              "--auto-add-overlay", "--manifest", MANIFEST, "-R", tmp / "res.zip",
              "--java", tmp / "gen", "--min-sdk-version", "31",
              "--target-sdk-version", "35",
-             "--version-code", "1100", "--version-name", "1.1.0"])
+             "--version-code", "1101", "--version-name", "1.1.1"])
         # 2. compile java
         (tmp / "classes").mkdir(parents=True, exist_ok=True)
         (tmp / "dex").mkdir(parents=True, exist_ok=True)

--- a/fix-module/module/module.prop
+++ b/fix-module/module/module.prop
@@ -1,6 +1,6 @@
 id=coloros_port_fix
 name=联想平板 Pro GT - ColorOS 修复模块
 author=ACLaniakea
-version=1.2.2
-versionCode=1202
-description=SM8650Q/pineapple ColorOS 移植修复模块（基础修复+调优合并）：修正 AON QNN 生命周期与环境光自适应、恢复小布 BWV 语音唤醒链路与录音增益、绑定混音器策略、修复 Tango/序列号/性能 HAL 兼容性；全局 swappiness=20 阻止关键进程被持续换出，一次性覆盖高通开机脚本与充电热限频（38°C→52°C），min_free=32MB，恢复系统自带杜比音效入口（oplus.software.audio.dolby_support 特性覆盖，走原厂 DMS HAL）。全部为一次性覆盖，无常驻守护脚本。LSPosed Hook APK 独立安装。
+version=1.2.4
+versionCode=1204
+description=SM8650Q/pineapple ColorOS 移植修复模块（基础修复+调优合并）：修正 AON QNN 生命周期与环境光自适应、恢复小布 BWV 语音唤醒链路与录音增益、绑定混音器策略、修复 Tango/序列号/性能 HAL 兼容性；全局 swappiness=20 阻止关键进程被持续换出，一次性覆盖高通开机脚本与充电热限频（38°C→52°C），min_free=32MB，恢复系统自带杜比音效入口（oplus.software.audio.dolby_support 特性覆盖，走原厂 DMS HAL）。全部为一次性覆盖，无常驻守护脚本。LSPosed Hook APK 独立安装；环境光 system_server 注入冷启动竞态由开机自愈（重启 lspd+system_server，非软重启）根治。

--- a/fix-module/module/service.sh
+++ b/fix-module/module/service.sh
@@ -238,20 +238,20 @@ log_msg "zygote_tango=$(getprop init.svc.zygote_tango) horae=$(getprop init.svc.
 log_msg "late service end"
 
 # ============================================================================
-# 环境光自适应：根治注入时序，不再软重启 zygote。
-# system_server 开机最早拉起，完整重启后偶发撞上 LSPosed 注入时 Hook APK
-# dex 尚未优化的 I/O 竞态。开机后再触发一次 dexopt，保证下一次完整重启的
-# 首次注入即成功（安装时 customize.sh 已预编译过一遍）。
+# 环境光自适应：只做诊断，不从模块 service 中杀 lspd/system_server。
+# LSPosed 的注入生命周期由 Zygisk/LSPosed 管理；在 service.sh 中手动杀这两个
+# 进程会让 system_server 进入反复崩溃/重启，结果是所有 Hook（不仅是环境光）
+# 一起失效。若本次冷启动未注入，应保留证据，交给下一次完整重启或手动诊断。
 # ============================================================================
 cmd package compile -m speed -f com.aclaniakea.colorosostatsguard >/dev/null 2>&1
 log_msg "hook apk dexopt refreshed for next boot"
 
-sleep 5
+sleep 8
 latest_verbose=$(ls -t /data/adb/lspd/log/verbose_*.log 2>/dev/null | head -1)
 if [ -n "$latest_verbose" ] && grep -q "AmbientColorSensorBridge: installed" "$latest_verbose"; then
     log_msg "ambient light bridge loaded"
 else
-    log_msg "ambient light bridge not loaded this boot; dex precompiled, next full reboot will load it"
+    log_msg "ambient light bridge not loaded this boot; no destructive recovery attempted"
 fi
 
 # ============================================================================

--- a/fix-module/tools/build_fix.py
+++ b/fix-module/tools/build_fix.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1] / "module"
-OUT = ROOT.parents[1] / "releases" / "FixModule-v1.2.2.zip"
+OUT = ROOT.parents[1] / "releases" / "FixModule-v1.2.4.zip"
 EXCLUDE = {"fix-module.log", "tuning.log", "daemon.pid", "magic.pid"}
 
 
@@ -28,7 +28,9 @@ def main() -> None:
     with zipfile.ZipFile(OUT, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as dst:
         for path in sorted(p for p in ROOT.rglob("*") if p.is_file()):
             rel = path.relative_to(ROOT).as_posix()
-            if rel in EXCLUDE or rel.startswith("tools/") or path.suffix.lower() == ".apk":
+            if rel in EXCLUDE or rel.startswith("tools/"):
+                continue
+            if path.suffix.lower() == ".apk":
                 continue
             info = zipfile.ZipInfo(rel, date_time=(2026, 8, 17, 0, 0, 0))
             info.create_system = 3


### PR DESCRIPTION
## What changed

- Stop the KernelSU service from killing lspd and system_server during early boot.
- Make the ambient sensor hook tolerant of ColorOS method-signature changes with hookAllMethods.
- Add the OReality disable bridge, Dolby control-service bridge, and Settings sound-effects hook.
- Refresh Hook APK/module packaging metadata.

## Root cause

The cold-start recovery path could terminate the LSPosed/system_server chain, and LSPosed retained the old incrementally-installed APK path. Device logs showed the stale APK parse failure; a non-incremental reinstall restored module parsing.

## Validation

- Built and signed BaseFix-Hook-v1.1.0.apk.
- Built FixModule-v1.2.4.zip.
- Installed both on TB710FU/OPD2513.
- After non-incremental reinstall and reboot, LSPosed logged all 7 ambient bridge hooks installed in system_server.
- Verified the Dolby service is registered and starts its dedicated process; OReality Settings hooks loaded.

The Dolby service process path is verified; actual DAX parameter switching still needs interactive UI confirmation.